### PR TITLE
Removes arrows from input number

### DIFF
--- a/styles/globals.css
+++ b/styles/globals.css
@@ -21,3 +21,12 @@ a {
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+@layer base {
+
+  input[type="number"]::-webkit-inner-spin-button,
+  input[type="number"]::-webkit-outer-spin-button {
+    -webkit-appearance: none;
+    margin: 0;
+  }
+}


### PR DESCRIPTION
## What problem does this solve?
When going to type your Discord ID, since it is an input type number, some arrows to increase and decrease the number appear on the right of the Input.
![Input arrows](https://user-images.githubusercontent.com/42651514/203186538-1ae7b3cf-13ba-4c03-900b-f227cdae1c8f.png)
But it isn't meant to have those arrows, since we don't want a literal number for a math expression or something, we want a correctly typed ID, so increasing or decreasing doesn't make sense, but the possibility of only typing number does, so it keeps the input as number but removes the arrows.

## How it solves the problem?
Since SingWatch uses Tailwind, I added a base layer at the globals css file, to remove the input number arrows pseudo-elements by changing their `margin` to 0, and `-webkit-appearance` to none to guarantee more browser accessibility.
![Input number without arrows](https://user-images.githubusercontent.com/42651514/203187019-a409bd5a-eabb-4998-833c-a61b68dfe2a4.png)
